### PR TITLE
Change type of IDs to string to fix validator errors

### DIFF
--- a/data/2016_shader_showdown_revision.json
+++ b/data/2016_shader_showdown_revision.json
@@ -9,7 +9,7 @@
 			"title": "Qualifiers #1",
 			"vod": "https://www.youtube.com/watch?v=n7eoUklvA6k",
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": 2,
 					"points": null,
 					"handle": "visy",
@@ -17,7 +17,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": 1,
 					"points": null,
 					"handle": "archee",
@@ -47,7 +47,7 @@
 			"title": "Qualifiers #2",
 			"vod": "https://www.youtube.com/watch?v=n7eoUklvA6k",
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": 2,
 					"points": null,
 					"handle": "mankeli",
@@ -55,7 +55,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": 1,
 					"points": null,
 					"handle": "blueberry",
@@ -85,7 +85,7 @@
 			"title": "Qualifiers #3",
 			"vod": "https://www.youtube.com/watch?v=n7eoUklvA6k",
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": 1,
 					"points": null,
 					"handle": "musk",
@@ -93,7 +93,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": 2,
 					"points": null,
 					"handle": "medo",
@@ -123,7 +123,7 @@
 			"title": "Qualifiers #4",
 			"vod": "https://www.youtube.com/watch?v=n7eoUklvA6k",
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": 1,
 					"points": null,
 					"handle": "lj",
@@ -131,7 +131,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": 2,
 					"points": null,
 					"handle": "kabuto",
@@ -161,7 +161,7 @@
 			"title": "Semifinals #1",
 			"vod": "https://www.youtube.com/watch?v=Oa0BlHkYynU",
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": 1,
 					"points": null,
 					"handle": "archee",
@@ -169,7 +169,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": 2,
 					"points": null,
 					"handle": "blueberry",
@@ -199,7 +199,7 @@
 			"title": "Semifinals #2",
 			"vod": "https://www.youtube.com/watch?v=Oa0BlHkYynU",
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": 2,
 					"points": null,
 					"handle": "musk",
@@ -207,7 +207,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": 1,
 					"points": null,
 					"handle": "lj",
@@ -237,7 +237,7 @@
 			"title": "Final",
 			"vod": "https://www.youtube.com/watch?v=slSmOqdL-rw",
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": 2,
 					"points": null,
 					"handle": "archee",
@@ -245,7 +245,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": 1,
 					"points": null,
 					"handle": "lj",

--- a/data/2018_shader_showdown_cookie.json
+++ b/data/2018_shader_showdown_cookie.json
@@ -9,7 +9,7 @@
 			"title": "Qualifiers #1",
 			"vod": "https://www.youtube.com/watch?v=p4MakgvYtGg",
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": null,
 					"points": null,
 					"handle": "Elie",
@@ -17,7 +17,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": null,
 					"points": null,
 					"handle": "wsmind",
@@ -31,7 +31,7 @@
 			"title": "Qualifiers #2",
 			"vod": "https://www.youtube.com/watch?v=n7eoUklvA6k",
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": 2,
 					"points": null,
 					"handle": "evvvvil",
@@ -39,7 +39,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": 1,
 					"points": null,
 					"handle": "ponk",
@@ -53,7 +53,7 @@
 			"title": "Qualifiers #3",
 			"vod": "https://www.youtube.com/watch?v=m4dznEOk6pw",
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": 2,
 					"points": null,
 					"handle": "lsdlive",
@@ -61,7 +61,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": 1,
 					"points": null,
 					"handle": "Flopine",
@@ -75,7 +75,7 @@
 			"title": "Qualifiers #4",
 			"vod": "https://www.youtube.com/watch?v=n7eoUklvA6k",
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": 2,
 					"points": null,
 					"handle": "eybor",
@@ -83,7 +83,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": 1,
 					"points": null,
 					"handle": "NuSan",
@@ -97,7 +97,7 @@
 			"title": "Semifinals #1",
 			"vod": null,
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": 2,
 					"points": null,
 					"handle": "Elie",
@@ -105,7 +105,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": 1,
 					"points": null,
 					"handle": "ponk",
@@ -119,7 +119,7 @@
 			"title": "Semifinals #2",
 			"vod": null,
 			"entries": [{
-					"id": 1,
+					"id": "1",
 					"rank": 2,
 					"points": null,
 					"handle": "Flopine",
@@ -127,7 +127,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 2,
+					"id": "2",
 					"rank": 1,
 					"points": null,
 					"handle": "NuSan",
@@ -141,7 +141,7 @@
 			"title": "Final",
 			"vod": null,
 			"entries": [{
-					"id": 2,
+					"id": "2",
 					"rank": 1,
 					"points": null,
 					"handle": "NuSan",
@@ -149,7 +149,7 @@
 					"shadertoy_url": null
 				},
 				{
-					"id": 1,
+					"id": "1",
 					"rank": 1,
 					"points": null,
 					"handle": "ponk",

--- a/data/2018_shader_showdown_deadline.json
+++ b/data/2018_shader_showdown_deadline.json
@@ -11,7 +11,7 @@
       "vod": "https://www.youtube.com/watch?v=gnOBOoyAouQ",
       "entries": [
         {
-          "id": 2,
+          "id": "2",
           "rank": 1,
           "points": null,
           "handle": "rimina",
@@ -19,7 +19,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 1,
+          "id": "1",
           "rank": 2,
           "points": null,
           "handle": "KeyJ",
@@ -43,7 +43,7 @@
       "vod": "https://www.youtube.com/watch?v=gnOBOoyAouQ",
       "entries": [
         {
-          "id": 1,
+          "id": "1",
           "rank": 2,
           "points": null,
           "handle": "lj",
@@ -51,7 +51,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 2,
+          "id": "2",
           "rank": 1,
           "points": null,
           "handle": "cupe",
@@ -75,7 +75,7 @@
       "vod": "https://www.youtube.com/watch?v=84DlrXXFNhc",
       "entries": [
         {
-          "id": 1,
+          "id": "1",
           "rank": 2,
           "points": null,
           "handle": "rimina",
@@ -83,7 +83,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 2,
+          "id": "2",
           "rank": 1,
           "points": null,
           "handle": "cupe",

--- a/data/2018_shader_showdown_demosplash.json
+++ b/data/2018_shader_showdown_demosplash.json
@@ -11,7 +11,7 @@
       "vod": "https://scenesat.com/videoarchive/250b96a5-b90e-11ea-b68e-00505685775e?t=10770",
       "entries": [
         {
-          "id": 2,
+          "id": "2",
           "rank": 1,
           "points": 185,
           "handle": "CharStiles",
@@ -19,7 +19,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 1,
+          "id": "1",
           "rank": 2,
           "points": 159,
           "handle": "lsh",

--- a/data/2018_shader_showdown_outline.json
+++ b/data/2018_shader_showdown_outline.json
@@ -11,7 +11,7 @@
       "vod": "https://www.youtube.com/watch?v=q8iFI1-v5n8",
       "entries": [
         {
-          "id": 1,
+          "id": "1",
           "rank": 1,
           "points": null,
           "handle": "lsdlive",
@@ -19,7 +19,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 2,
+          "id": "2",
           "rank": 2,
           "points": null,
           "handle": "TropicalTrevor",
@@ -48,7 +48,7 @@
       "vod": "https://youtu.be/q8iFI1-v5n8?t=1618",
       "entries": [
         {
-          "id": 1,
+          "id": "1",
           "rank": 2,
           "points": null,
           "handle": "lj",
@@ -56,7 +56,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 2,
+          "id": "2",
           "rank": 1,
           "points": null,
           "handle": "Flopine",
@@ -85,7 +85,7 @@
       "vod": "https://youtu.be/q8iFI1-v5n8?t=3344",
       "entries": [
         {
-          "id": 1,
+          "id": "1",
           "rank": 1,
           "points": null,
           "handle": "lsdlive",
@@ -93,7 +93,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 2,
+          "id": "2",
           "rank": 2,
           "points": null,
           "handle": "Flopine",

--- a/data/2019_shader_showdown_uitfeest.json
+++ b/data/2019_shader_showdown_uitfeest.json
@@ -11,7 +11,7 @@
       "vod": null,
       "entries": [
         {
-          "id": 1,
+          "id": "1",
           "rank": null,
           "points": null,
           "handle": "Sasj",
@@ -19,7 +19,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 2,
+          "id": "2",
           "rank": null,
           "points": null,
           "handle": "lucidlien",
@@ -44,7 +44,7 @@
       "vod": null,
       "entries": [
         {
-          "id": 1,
+          "id": "1",
           "rank": 1,
           "points": null,
           "handle": "Flopine",
@@ -52,7 +52,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 2,
+          "id": "2",
           "rank": 2,
           "points": null,
           "handle": "evvvvil",
@@ -77,7 +77,7 @@
       "vod": null,
       "entries": [
         {
-          "id": 1,
+          "id": "1",
           "rank": null,
           "points": null,
           "handle": "Sasj",
@@ -85,7 +85,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 2,
+          "id": "2",
           "rank": 1,
           "points": null,
           "handle": "Flopine",

--- a/data/2020_shader_showdown_fieldfx.json
+++ b/data/2020_shader_showdown_fieldfx.json
@@ -11,7 +11,7 @@
       "vod": "https://www.youtube.com/watch?v=Jt0cvOIoHWQ",
       "entries": [
         {
-          "id": 2,
+          "id": "2",
           "rank": 1,
           "points": 59,
           "handle": "monsieursoleil",
@@ -19,7 +19,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 1,
+          "id": "1",
           "rank": 2,
           "points": 55,
           "handle": "evvvvil",
@@ -55,7 +55,7 @@
       "vod": "https://www.youtube.com/watch?v=Jt0cvOIoHWQ",
       "entries": [
         {
-          "id": 1,
+          "id": "1",
           "rank": 1,
           "points": 67,
           "handle": "Flopine",
@@ -63,7 +63,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 2,
+          "id": "2",
           "rank": 2,
           "points": 66,
           "handle": "blackle",
@@ -91,7 +91,7 @@
       "vod": "https://www.youtube.com/watch?v=f3JGkVQcuX0",
       "entries": [
         {
-          "id": 2,
+          "id": "2",
           "rank": 1,
           "points": 90,
           "handle": "monsieursoleil",
@@ -99,7 +99,7 @@
           "shadertoy_url": null
         },
         {
-          "id": 1,
+          "id": "1",
           "rank": 2,
           "points": 71,
           "handle": "Flopine",


### PR DESCRIPTION
Fixes validation errors like:

```
ERROR: 1 is not of type 'string', 'null'

Failed validating 'type' in schema['properties']['phases']['items']['properties']['entries']['items']['properties']['id']:
    {'description': 'User Id for the phase (usually for Shader Royale)',
     'type': ['string', 'null']}

On instance['phases'][0]['entries'][0]['id']:
    1ERROR: 2 is not of type 'string', 'null'
```