### PR TITLE
Remove duplicate organizer entry from 2024_03_03_byte_jam_instanssi.json

### DIFF
--- a/public/data/2024_03_03_byte_jam_instanssi.json
+++ b/public/data/2024_03_03_byte_jam_instanssi.json
@@ -71,13 +71,6 @@
             "staffs": [
                 {
                     "handle": {
-                        "name": "RaccoonViolet",
-                        "demozoo_id": 90373
-                    },
-                    "job": "Organizer"
-                },
-                {
-                    "handle": {
                         "name": "OGsuntio",
                         "demozoo_id": null
                         },


### PR DESCRIPTION
By convention "Organizer" roles are at the top level